### PR TITLE
Add prevent default to down arrow

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,5 +62,9 @@ document.addEventListener('keydown', function (event) {
     event.preventDefault();
     ship.rotateRight();
     break;
+
+    case 40:
+    event.preventDefault();
+    break;
   }
 });


### PR DESCRIPTION
Add `preventDefault` to stop screen from scrolling when down arrow is pressed.
